### PR TITLE
Fix Pagination docstring

### DIFF
--- a/app/responses/user.py
+++ b/app/responses/user.py
@@ -40,9 +40,9 @@ class Pagination(BaseModel):
     Pydantic model representing pagination information.
 
     Attributes:
-        page (int): The current page number.
+        current_page (int): The current page number.
         items_per_page (int): The number of items per page.
-        total_items (int): The total number of items.
+        total (int): The total number of items.
     """
 
     current_page: int


### PR DESCRIPTION
## Summary
- fix Pagination docstring to refer to `current_page`
- correct `total_items` reference to `total`

## Testing
- `pytest -q` *(fails: pyenv: version `3.11.11` is not installed)*

------
https://chatgpt.com/codex/tasks/task_e_68481481e050832d867766edf07f0ca6