### PR TITLE
Fix bug in user response serialization

### DIFF
--- a/app/responses/user.py
+++ b/app/responses/user.py
@@ -8,8 +8,8 @@ class UserResponse(BaseModel):
     id: int
     username: str
     email: str
-    created_at: str
-    updated_at: str
+    created_at: datetime
+    updated_at: datetime
 
     model_config = ConfigDict(from_attributes=True)
 
@@ -80,8 +80,8 @@ class UserCreateResponse(BaseModel):
     id: int
     username: str
     email: str
-    created_at: str
-    updated_at: str
+    created_at: datetime
+    updated_at: datetime
 
 
 class UserUpdateResponse(BaseModel):
@@ -97,5 +97,5 @@ class UserUpdateResponse(BaseModel):
     id: int
     username: str
     email: str
-    created_at: str
-    updated_at: str
+    created_at: datetime
+    updated_at: datetime


### PR DESCRIPTION
## Summary
- fix serialization types in `UserResponse` models for datetime fields

## Testing
- `python3 -m py_compile app/responses/user.py`
- *Codex couldn't run certain commands due to environment limitations. Consider configuring a setup script or internet access in your Codex environment to install dependencies.*

------
https://chatgpt.com/codex/tasks/task_e_68480c3a7e20832d8fdcb21e746dcab5